### PR TITLE
Add CLI, add /bin to patchelf search path.

### DIFF
--- a/extract_manylinux/extract.py
+++ b/extract_manylinux/extract.py
@@ -130,6 +130,8 @@ class Extractor:
         # Set patchelf, if not provided.
         if self.patchelf is None:
             paths = (
+                # Rocky linux installs 'patchelf' into /bin
+                Path('/bin'),
                 Path(__file__).parent / 'bin',
                 Path.home() / '.local/bin'
             )
@@ -138,7 +140,7 @@ class Extractor:
                 if patchelf.exists():
                     break
             else:
-                raise NotImplementedError()
+                raise FileNotFoundError(f"'patchelf' not found in any of: {[str(p) for p in paths]}")
             object.__setattr__(self, 'patchelf', patchelf)
         else:
             assert(self.patchelf.exists())

--- a/extractor_cli.py
+++ b/extractor_cli.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+import argparse
+from pathlib import Path
+import sys
+from extract_manylinux.extract import Arch, Extractor
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extracts CPython runtime from a Manylinux image")
+    parser.add_argument("--arch", choices=tuple(str(a) for a in Arch), required=True, help="Target architecture")
+    parser.add_argument("--prefix", metavar="PATH", type=Path, required=True, help="Path to the exported container image root")
+    parser.add_argument("--tag", required=True, help="Python binary tag (ex: cp311-cp311; select from symlinks in $PREFIX/opt/python)")
+    parser.add_argument("--output", "-o", required=True, type=Path, help="Path to store the resulting Relocatable CPython Runtime (RCPR)")
+    parsed_args = parser.parse_args()
+
+    arch = Arch[parsed_args.arch.upper()]
+    destination: Path = parsed_args.output
+
+    if destination.exists():
+        raise FileExistsError(f"{destination} exists")
+
+    extractor = Extractor(
+        arch=arch,
+        prefix=parsed_args.prefix,
+        tag=parsed_args.tag,
+    )
+
+    extractor.extract(destination)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Hi Valentin,

I added a CLI tool to call the extractor, and then added "/bin" to the search path for patchelf.  Rocky 9 has a 'patchelf' package and this is where it gets installed to.

Thanks again for putting this together -- really saved me a TON of time.
